### PR TITLE
Allow multiple uses of generated middleware with `express-once`.

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -5,7 +5,8 @@ var _ = require('lodash'),
 	assign = require('./assign'),
 	challenge = require('./challenge'),
 	verify = require('express-authentication-verify'),
-	async = require('express-async');
+	async = require('express-async'),
+	once = require('express-once');
 
 module.exports = function create(options) {
 
@@ -15,9 +16,9 @@ module.exports = function create(options) {
 		challenge: challenge(options)
 	};
 
-	return _.assign(async.serial(
+	return _.assign(once(async.serial(
 		result.assign,
 		result.verify,
 		result.challenge
-	), result);
+	)), result);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"auth-header": "^0.2.2",
 		"express-async": "^0.1.3",
 		"express-authentication-verify": "^0.1.0",
+		"express-once": "^0.1.0",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {

--- a/test/spec/header.spec.js
+++ b/test/spec/header.spec.js
@@ -1,7 +1,9 @@
 
 'use strict';
 
-var header = require('header');
+var header = require('header'),
+	express = require('express'),
+	request = require('supertest');
 
 describe('header', function() {
 	it('should return a function', function() {
@@ -9,5 +11,34 @@ describe('header', function() {
 			scheme: 'Basic',
 			verify: function() { }
 		})).to.be.instanceof(Function);
+	});
+
+	it('should authenticate if used multiple times', function(done) {
+		var middleware = header({
+			scheme: 'Test',
+			verify: function(token, callback) {
+				callback(null, true);
+			}
+		});
+
+		var app = express();
+
+		app.use(middleware);
+		app.get('/secret', middleware, function(req, res) {
+			res.status(200).send({
+				challenge: !!req.challenge,
+				authenticated: req.authenticated
+			});
+		});
+
+		request(app)
+			.get('/secret')
+			.set('Authorization', 'Test foo')
+			.expect(function(res) {
+				expect(res.statusCode).to.equal(200);
+				expect(res.body).to.have.property('challenge', true);
+				expect(res.body).to.have.property('authenticated', true);
+			})
+			.end(done);
 	});
 });


### PR DESCRIPTION
Sometimes by using context chaining in `express-authentication` or general forgetfulness one includes the generated authentication middleware twice. Since authentication should be idempotent with respect to a request we now just skip any subsequent calls to the middleware offering better speed and no confusion about the `req.challenge` check that ensures other middleware isn't clobbering us. All existing code should work just fine with this. Specs added to verify this behavior.